### PR TITLE
fix some warnings

### DIFF
--- a/src/core/utils/connection_handling.rs
+++ b/src/core/utils/connection_handling.rs
@@ -1,8 +1,8 @@
 use crate::managers::connections::connection::Connection;
-use crate::core_structures::connection_protocol::ConnectionProtocolMessage;
 
-use tokio::io::AsyncWriteExt;
-use crate::core::utils::connection_handling::api::opcode_parser::OpCodes;
+
+
+
 
 pub mod api;
 

--- a/src/core/utils/connection_handling/api/opcode_parser.rs
+++ b/src/core/utils/connection_handling/api/opcode_parser.rs
@@ -1,5 +1,6 @@
 /// The enumerator defining the different operation codes, and their respective identifiers, see [here](https://kalavar.cf/documentation/general/opcodes/)
 // Format: Name // ID
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum OpCodes {
     Normal,          // 00

--- a/src/core_structures/column.rs
+++ b/src/core_structures/column.rs
@@ -1,13 +1,24 @@
 /// Bit count definitions, used in storage calculations
+#[allow(dead_code)]
 const BIT: u64 = 1;
+#[allow(dead_code)]
+
 const BYTE: u64 = 8 * BIT;
+#[allow(dead_code)]
+
 const KB: u64 = 1024 * BYTE;
+#[allow(dead_code)]
+
 const MB: u64 = 1024 * KB;
+#[allow(dead_code)]
+
 const GB: u64 = 1024 * MB;
+#[allow(dead_code)]
 
 /// An enumerator which defines the available column types
 /// I recommend reading the documentation at the link below for details on them all:
 /// <https://kalavar.cf/documentation/data-types/>
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum ColumnTypeEnum {
     // Text Types
@@ -102,12 +113,16 @@ pub struct ColumnType {
     pub value_type: Option<ColumnTypeEnum>,
 }
 
-
 impl ColumnType {
     /// Helper method to generate a new column
-    pub fn new(inner: ColumnTypeEnum, value_type: Option<ColumnTypeEnum>, length: u64) -> ColumnType {
+    #[allow(dead_code)]
+    pub fn new(
+        inner: ColumnTypeEnum,
+        value_type: Option<ColumnTypeEnum>,
+        length: u64,
+    ) -> ColumnType {
         // Build a default column entry
-        let mut t = ColumnType {
+        let t = ColumnType {
             is_private: false,
             inner_type: inner.clone(),
             min_len: 0,
@@ -120,9 +135,14 @@ impl ColumnType {
     }
 
     /// Helper method to generate a new private column which remains hidden from query results
-    pub fn new_prv(inner: ColumnTypeEnum, value_type: Option<ColumnTypeEnum>, length: u64) -> ColumnType {
+    #[allow(dead_code)]
+    pub fn new_prv(
+        inner: ColumnTypeEnum,
+        value_type: Option<ColumnTypeEnum>,
+        length: u64,
+    ) -> ColumnType {
         // Build a default column entry
-        let mut t = ColumnType {
+        let t = ColumnType {
             is_private: true,
             inner_type: inner.clone(),
             min_len: 0,

--- a/src/core_structures/connection_protocol.rs
+++ b/src/core_structures/connection_protocol.rs
@@ -2,6 +2,7 @@
 use crate::core::utils::connection_handling::api::opcode_parser::OpCodes;
 
 /// An enum describing the types of data that a ConnectionProtocolMessage may contain
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum DataType {
     /// The payload contained is within the String section

--- a/src/core_structures/database_record.rs
+++ b/src/core_structures/database_record.rs
@@ -2,8 +2,8 @@
 use std::collections::HashMap;
 
 // External crate imports
-use tokio::fs::File;
-use serde::{Serialize, Deserialize};
+
+
 
 // Internal crate imports
 use crate::core_structures::table_record::TableRecord;
@@ -28,6 +28,7 @@ pub struct DatabaseRecord {
 
 /// # The following content is undocumented due to not being ready for documentation at this time.
 /// # You are welcome to attempt to make sense of it though.
+#[allow(dead_code)]
 impl DatabaseRecord {
 
     pub fn new(name: String, backing: String) -> DatabaseRecord {

--- a/src/core_structures/row.rs
+++ b/src/core_structures/row.rs
@@ -25,6 +25,7 @@ pub struct Cell {
 
 /// # The following content is undocumented due to not being ready for documentation at this time.
 /// # You are welcome to attempt to make sense of it though.
+#[allow(dead_code)]
 impl Row {
     pub fn new(cells: Vec<(String, ColumnType)>) -> Row {
         let mut r = Row {

--- a/src/core_structures/row_record.rs
+++ b/src/core_structures/row_record.rs
@@ -2,10 +2,10 @@
 use std::collections::HashMap;
 
 // External crate imports
-use serde::{Serialize, Deserialize};
+
 
 // Internal crate imports
-use crate::core_structures::table::Table;
+
 use crate::core_structures::row::Row;
 
 /// Helper structure used to reference specific rows for a specific table in a database

--- a/src/core_structures/table.rs
+++ b/src/core_structures/table.rs
@@ -17,6 +17,7 @@ pub struct Table {
     /// An (unsorted) array of all the rows in this table
     pub rows: Vec<Row>,
 }
+#[allow(dead_code)]
 
 impl Table {
     /// Helper method designed to instantiate a new table on behalf of the caller

--- a/src/core_structures/table_record.rs
+++ b/src/core_structures/table_record.rs
@@ -2,7 +2,6 @@
 use std::collections::HashMap;
 
 // External crate imports
-use serde::{Serialize, Deserialize};
 
 // Internal crate imports
 use crate::core_structures::table::Table;
@@ -40,6 +39,7 @@ pub struct TableRecord {
 /// # The following content is undocumented due to not being ready for documentation at this time.
 /// # You are welcome to attempt to make sense of it though.
 impl TableRecord {
+    #[allow(dead_code)]
     pub fn new(name: &str, columns: &Vec<(String, ColumnType)>, start: u64) -> TableRecord {
         let mut t = TableRecord {
             inner: Table {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::error::Error;
 
 #[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
 pub enum ErrorMap {
     // General Errors
     /// Unknown error, needs to be mapped to error code

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ async fn main() {
     // This is important as the program requires this at all levels for debugging
     let mut logger = LoggingManager::new();
 
-    logger.init();
+    logger.init().await;
 
     // Instantiate a new instance of the config manager
     // Used to parse the configuration file into something the server can make use of

--- a/src/managers/authentication.rs
+++ b/src/managers/authentication.rs
@@ -1,6 +1,7 @@
 use crate::managers::permission::PermissionManager;
 
 /// A utility structure for managing authentication with the client
+#[allow(dead_code)]
 pub struct AuthManager {
     /// A structure representing the permissions that the user has across all of the system
     pub permissions: PermissionManager,

--- a/src/managers/encryption.rs
+++ b/src/managers/encryption.rs
@@ -33,25 +33,27 @@ impl EncryptionManager {
             println!("{} bytes", payload.len());
 
             let mut writer = BufWriter::new(&mut self.stream);
-            writer.write_all(payload.as_slice()).await;
-            writer.flush().await;
+            writer.write_all(payload.as_slice()).await.unwrap();
+            writer.flush().await.unwrap();
             println!("key transmitted");
         }
     }
 
 
     /// Encrypt and then write the provided data to the TcpStream and flush the buffer so that it is transmitted to the client for processing
+    #[allow(dead_code)]
     pub async fn write<A: AsBytes>(&mut self, data: &A) {
         let ciphertext = seal(&self.key, data.as_kv_bytes().as_slice());
         if ciphertext.is_ok() {
             let mut writer = BufWriter::new(&mut self.stream);
-            writer.write_all(ciphertext.unwrap().as_slice()).await;
-            writer.flush().await;
+            writer.write_all(ciphertext.unwrap().as_slice()).await.unwrap();
+            writer.flush().await.unwrap();
         }
     }
 
     /// (OBSOLETE) Read and subsequently decrypt the data received from the client
-    pub fn read(&mut self, reader: &mut BufReader<TcpStream>) {
+    #[allow(dead_code)]
+    pub fn read(&mut self, _reader: &mut BufReader<TcpStream>) {
         // let data = open(&self.key, )
     }
 }

--- a/src/managers/implementors/managers/config.rs
+++ b/src/managers/implementors/managers/config.rs
@@ -1,13 +1,13 @@
 // STD Lib imports
-use std::string::FromUtf8Error;
+
 
 // External crate imports
-use tokio::fs::{File, create_dir_all};
+use tokio::fs::{File};
 use tokio::io;
-use tokio::io::{AsyncReadExt, ErrorKind, AsyncWriteExt};
+
 
 // Internal crate imports
-use crate::managers::config::{ConfigManager, Config, NetConfig, LanguageConfig, LogConfig};
+use crate::managers::config::{ConfigManager};
 use crate::managers::logging::LoggingManager;
 use crate::errors::ErrorMap::*;
 
@@ -42,7 +42,7 @@ impl ConfigManager {
         }
 
         // Attempt to open the config file
-        let mut file: io::Result<File> = File::open(&manager.config_path).await;
+        let _file: io::Result<File> = File::open(&manager.config_path).await;
 
         // If the file is okay, parse the file
         // If it is not, check the type of the error and act accordingly

--- a/src/managers/implementors/managers/connections/connection_manager.rs
+++ b/src/managers/implementors/managers/connections/connection_manager.rs
@@ -99,7 +99,7 @@ impl ConnectionManager {
                 // Create an endless loop
                 loop {
                     // Update memory values
-                    epoch::advance();
+                    epoch::advance().unwrap();
 
                     // Get the amount of RAM the process is using at the current time as a floating point value
                     let used = stats::allocated::read().unwrap() as f64;
@@ -108,7 +108,7 @@ impl ConnectionManager {
                     let total = stats::resident::read().unwrap() as f64;
 
                     // Report the used and total values to the protocol thread for action
-                    memtra.send(ConnectionProtocolMessage::new_mem(used, total));
+                    memtra.send(ConnectionProtocolMessage::new_mem(used, total)).unwrap();
 
                     // Sleep the whole thread for 20 seconds to avoid cpu usage spikes
                     tokio::time::sleep(Duration::from_secs(20)).await;
@@ -140,7 +140,7 @@ impl ConnectionManager {
 
                 // Spawn a thread to handle the connection and any requests it decides to make
                 tokio::spawn(async move {
-                    connection.transmitter.send(ConnectionProtocolMessage::new_con(&connection.id));
+                    connection.transmitter.send(ConnectionProtocolMessage::new_con(&connection.id)).unwrap();
                     connection.stream.init().await;
                     crate::core::utils::connection_handling::handle(connection).await
                 });

--- a/src/managers/implementors/managers/logging.rs
+++ b/src/managers/implementors/managers/logging.rs
@@ -21,6 +21,7 @@ const FG_YEL: &str = "\x1b[33m";
 const FG_GRE: &str = "\x1b[32m";
 const FG_CYA: &str = "\x1b[36m";
 const FG_MAG: &str = "\x1b[35m";
+#[allow(dead_code)]
 const FG_GRY: &str = "\x1b[2m\x1b[37m";
 
 impl LoggingManager {
@@ -71,7 +72,7 @@ impl LoggingManager {
 
         match file {
             Ok(mut f) => {
-                f.write_all(format!(" FATAL > {:?} > {} > {}\n", error, format_date().await, content).as_bytes()).await;
+                f.write_all(format!(" FATAL > {:?} > {} > {}\n", error, format_date().await, content).as_bytes()).await.unwrap();
             }
             _ => {}
         }
@@ -89,7 +90,7 @@ impl LoggingManager {
 
             match file {
                 Ok(mut f) => {
-                    f.write_all(format!(" DEBUG >      > {} > {}\n", format_date().await, c).as_bytes()).await;
+                    f.write_all(format!(" DEBUG >      > {} > {}\n", format_date().await, c).as_bytes()).await.unwrap();
                 }
                 _ => {}
             }
@@ -97,6 +98,7 @@ impl LoggingManager {
     }
 
     /// Prints content to the terminal and file without any pretty formatting
+    #[allow(dead_code)]
     pub async fn debug<A: Debug>(&self, content: A) {
         if self.levels.get("DEBUG").is_some() {
             println!(" {}DEBUG{} >      > {}{}{} > {}{:?}{}", FG_GRE, RESET, FG_MAG, format_date().await, RESET, FG_GRE, content, RESET);
@@ -106,7 +108,7 @@ impl LoggingManager {
 
             match file {
                 Ok(mut f) => {
-                    f.write_all(format!(" DEBUG >      > {} > {:?}\n", format_date().await, content).as_bytes()).await;
+                    f.write_all(format!(" DEBUG >      > {} > {:?}\n", format_date().await, content).as_bytes()).await.unwrap();
                 }
                 _ => {}
             }
@@ -128,7 +130,7 @@ impl LoggingManager {
 
                 match file {
                     Ok(mut f) => {
-                        f.write_all(format!(" DEBUG >      > {} > {}\n", format_date().await, line).as_bytes()).await;
+                        f.write_all(format!(" DEBUG >      > {} > {}\n", format_date().await, line).as_bytes()).await.unwrap();
                     }
                     _ => {}
                 }
@@ -146,13 +148,13 @@ impl LoggingManager {
 
             match file {
                 Ok(mut f) => {
-                    f.write_all(format!(" INFO  >      > {} > {}\n", format_date().await, content).as_bytes()).await;
+                    f.write_all(format!(" INFO  >      > {} > {}\n", format_date().await, content).as_bytes()).await.unwrap();
                 }
                 _ => {}
             }
         }
     }
-
+    #[allow(dead_code)]
     /// Prints information to the terminal and log file
     pub async fn log<A: Display>(&self, content: A) {
         if self.levels.get("LOG").is_some() {
@@ -163,7 +165,7 @@ impl LoggingManager {
 
             match file {
                 Ok(mut f) => {
-                    f.write_all(format!("  LOG  >      > {} > {}\n", format_date().await, content).as_bytes()).await;
+                    f.write_all(format!("  LOG  >      > {} > {}\n", format_date().await, content).as_bytes()).await.unwrap();
                 }
                 _ => {}
             }
@@ -179,7 +181,7 @@ impl LoggingManager {
 
             match file {
                 Ok(mut f) => {
-                    f.write_all(format!(" WARN  >      > {} > {}\n", format_date().await, content).as_bytes()).await;
+                    f.write_all(format!(" WARN  >      > {} > {}\n", format_date().await, content).as_bytes()).await.unwrap();
                 }
                 _ => {}
             }
@@ -200,7 +202,7 @@ impl LoggingManager {
 
             match file {
                 Ok(mut f) => {
-                    f.write_all(format!(" ERROR > {:?} > {} > {}\n", error, format_date().await, content).as_bytes()).await;
+                    f.write_all(format!(" ERROR > {:?} > {} > {}\n", error, format_date().await, content).as_bytes()).await.unwrap();
                 }
                 _ => {}
             }

--- a/src/managers/implementors/managers/storage.rs
+++ b/src/managers/implementors/managers/storage.rs
@@ -40,7 +40,7 @@ impl StorageManager {
 }
 
 /// Utility method to parse the database files within the data directory
-async fn parse_incoming(mut s: StorageManager, l: &LoggingManager) -> StorageManager {
+async fn parse_incoming(s: StorageManager, l: &LoggingManager) -> StorageManager {
     let mut failed: (bool, ErrorKind) = (false, ErrorKind::Other);
     let core_files: [&str;3] = ["/data/core/map.kgb", "/data/core/map.kdb", l.log_file.as_str()];
     for dir in core_files.iter() {

--- a/src/tests/structure_tests/core_structures/row.rs
+++ b/src/tests/structure_tests/core_structures/row.rs
@@ -1,10 +1,10 @@
-use crate::core_structures::row::{Row, Cell};
+use crate::core_structures::row::{Row};
 use crate::core_structures::column::{ColumnType, ColumnTypeEnum};
 use crate::core_structures::as_bytes::AsBytes;
 
 #[test]
 fn test_new_row() {
-    let mut c = ColumnType::new_prv(ColumnTypeEnum::Integer64, None, 64);
+    let c = ColumnType::new_prv(ColumnTypeEnum::Integer64, None, 64);
     let mut r = Row::new(vec![("__IDENTIFIER__".to_string(), c)]);
 
     r.entries.get_mut("__IDENTIFIER__").unwrap().inner_value = 64.as_kv_bytes();


### PR DESCRIPTION
This pr fixes warnings, mostly through the use of #[allow(dead_code)], and adding .unwrap() (particularly to src/managers/implementors/managers/logging.rs).
